### PR TITLE
generate 15 numeric hash for docusigh based on tab_type and email

### DIFF
--- a/docassemble/docusign/da_docusign.py
+++ b/docassemble/docusign/da_docusign.py
@@ -5,7 +5,6 @@ import time
 import jwt
 import json
 import base64
-import hashlib
 import re
 from docassemble.base.util import DAError, log, interview_url, DAObject, defined, get_config, all_variables, DARedis, user_info, url_of
 
@@ -258,6 +257,7 @@ def make_document_base64(document_path):
     with open(document_path, 'rb') as document:
         return base64.b64encode(document.read()).decode('utf-8')
         
-def generate_anchor(tab_type, email, uid=''):
-    """Generate standard anchor using SHA1 hash of email and standard abbreviation"""
-    return hashlib.sha1(email.encode('utf-8')).hexdigest()[:10] + TAB_TYPES[tab_type]['abbreviation'] + uid
+def generate_anchor(tab_type, email):
+    """Generate 15 numeric anchor using hash of tab_type and email"""
+    text = str(tab_type) + email
+    return abs(hash(text)) % (10 ** 15)


### PR DESCRIPTION
With this current hash, for the emails iasmini.gomes@gmail.com, silex@silexsistemas.com.br and others Docusign was not generating the signature tab in docx. I was having to drag the signature field to be able to sign the document. According to Docusign support, only a numeric tab should be generated. With the numeric tab it is working for both emails.
They didn't explain why it went wrong with just a few emails, but I think it must be an encoding error, although the hash didn't generate any special characters.
![iasmini gomes@gmail com](https://user-images.githubusercontent.com/5900939/87441399-7299c580-c5c9-11ea-8a89-c0fe686d88e7.png)
